### PR TITLE
Breaking message audit and saga audit into separate features

### DIFF
--- a/NServiceBus.Serilog.Tracing/MessageTracing.cs
+++ b/NServiceBus.Serilog.Tracing/MessageTracing.cs
@@ -1,0 +1,37 @@
+﻿using NServiceBus.Features;
+using NServiceBus.Pipeline;
+
+namespace NServiceBus.Serilog.Tracing {
+    public class MessageTracing : Feature
+    {
+        public MessageTracing() 
+        {
+            EnableByDefault();
+            DependsOn<TracingLog>();
+        }
+
+        protected override void Setup(FeatureConfigurationContext context) 
+        {
+            context.Pipeline.Register<ReceiveMessageRegistration>();
+            context.Pipeline.Register<SendMessageRegistration>();
+        }
+
+        class ReceiveMessageRegistration : RegisterStep 
+        {
+            public ReceiveMessageRegistration()
+                : base("SerilogReceiveMessage", typeof(ReceiveMessageBehavior), "Logs incoming messages") 
+            {
+                InsertBefore(WellKnownStep.MutateIncomingMessages);
+            }
+        }
+
+        class SendMessageRegistration : RegisterStep 
+        {
+            public SendMessageRegistration()
+                : base("SerilogSendMessage", typeof(SendMessageBehavior), "Logs outgoing messages") 
+            {
+                InsertAfter(WellKnownStep.DispatchMessageToTransport);
+            }
+        }
+    }
+}

--- a/NServiceBus.Serilog.Tracing/NServiceBus.Serilog.Tracing.csproj
+++ b/NServiceBus.Serilog.Tracing/NServiceBus.Serilog.Tracing.csproj
@@ -62,12 +62,14 @@
     <Compile Include="MessageAudit\SendMessageBehavior.cs" />
     <Compile Include="MessageAudit\ReceiveMessageBehavior.cs" />
     <Compile Include="MessageAudit\HeaderAppender.cs" />
+    <Compile Include="MessageTracing.cs" />
     <Compile Include="SagaAudit\CaptureSagaResultingMessagesBehavior.cs" />
     <Compile Include="SagaAudit\CaptureSagaStateBehavior.cs" />
     <Compile Include="SagaAudit\Data\SagaChangeInitiator.cs" />
     <Compile Include="SagaAudit\Data\SagaChangeOutput.cs" />
     <Compile Include="SagaAudit\Data\SagaUpdatedMessage.cs" />
     <Compile Include="NServiceBusExtensions.cs" />
+    <Compile Include="SagaTracing.cs" />
     <Compile Include="TracingLog.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NServiceBus.Serilog.Tracing/SagaTracing.cs
+++ b/NServiceBus.Serilog.Tracing/SagaTracing.cs
@@ -1,0 +1,38 @@
+﻿using NServiceBus.Features;
+using NServiceBus.Pipeline;
+
+namespace NServiceBus.Serilog.Tracing {
+    public class SagaTracing : Feature 
+    {
+        public SagaTracing() 
+        {
+            EnableByDefault();
+            DependsOn<Features.Sagas>();
+            DependsOn<TracingLog>();
+        }
+
+        protected override void Setup(FeatureConfigurationContext context) 
+        {
+            context.Pipeline.Register<CaptureSagaStateRegistration>();
+            context.Pipeline.Register<CaptureSagaResultingMessageRegistration>();
+        }
+
+        class CaptureSagaStateRegistration : RegisterStep 
+        {
+            public CaptureSagaStateRegistration()
+                : base("SerilogCaptureSagaState", typeof(CaptureSagaStateBehavior), "Records saga state changes") 
+            {
+                InsertBefore(WellKnownStep.InvokeSaga);
+            }
+        }
+
+        class CaptureSagaResultingMessageRegistration : RegisterStep 
+        {
+            public CaptureSagaResultingMessageRegistration()
+                : base("SerilogReportSagaStateChanges", typeof(CaptureSagaResultingMessagesBehavior), "Reports the saga state changes to Serilog") 
+            {
+                InsertAfter(WellKnownStep.InvokeSaga);
+            }
+        }
+    }
+}

--- a/NServiceBus.Serilog.Tracing/TracingLog.cs
+++ b/NServiceBus.Serilog.Tracing/TracingLog.cs
@@ -14,10 +14,6 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            context.Pipeline.Register<CaptureSagaStateRegistration>();
-            context.Pipeline.Register<CaptureSagaResultingMessageRegistration>();
-            context.Pipeline.Register<ReceiveMessageRegistration>();
-            context.Pipeline.Register<SendMessageRegistration>();
             ILogger logger;
             if (!context.Settings.TryGetSerilogTracingTarget(out logger))
             {
@@ -25,42 +21,6 @@
             }
             var logBuilder = new LogBuilder(logger, context.Settings.EndpointName());
             context.Container.ConfigureComponent(() => logBuilder, DependencyLifecycle.SingleInstance);
-        }
-
-        class CaptureSagaStateRegistration : RegisterStep
-        {
-            public CaptureSagaStateRegistration()
-                : base("SerilogCaptureSagaState", typeof(CaptureSagaStateBehavior), "Records saga state changes")
-            {
-                InsertBefore(WellKnownStep.InvokeSaga);
-            }
-        }
-
-        class CaptureSagaResultingMessageRegistration : RegisterStep
-        {
-            public CaptureSagaResultingMessageRegistration()
-                : base("SerilogReportSagaStateChanges", typeof(CaptureSagaResultingMessagesBehavior), "Reports the saga state changes to Serilog")
-            {
-                InsertAfter(WellKnownStep.InvokeSaga);
-            }
-        }
-
-        class ReceiveMessageRegistration : RegisterStep
-        {
-            public ReceiveMessageRegistration()
-                : base("SerilogReceiveMessage", typeof(ReceiveMessageBehavior), "Logs incoming messages")
-            {
-                InsertBefore(WellKnownStep.MutateIncomingMessages);
-            }
-        }
-
-        class SendMessageRegistration : RegisterStep
-        {
-            public SendMessageRegistration()
-                : base("SerilogSendMessage", typeof(SendMessageBehavior), "Logs outgoing messages")
-            {
-                InsertAfter(WellKnownStep.DispatchMessageToTransport);
-            }
         }
     }
 }


### PR DESCRIPTION
I found that the saga registration steps blow up when used in an endpoint that doesn't have any sagas.  My solution to this was to break the saga and messaging audit into separate features.